### PR TITLE
Update to new webex js sdk with read receipt functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,532 +19,6 @@
         }
       }
     },
-    "@ciscospark/common": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/common/-/common-1.50.19.tgz",
-      "integrity": "sha512-d3epnMPowdVy4v80tUM0+33JtwcAHH5Oe7LXvQnYYXlNjRHIv/E23YzjkHx5C2+cD149iz8+SOugFvOBbksLAg==",
-      "requires": {
-        "babel-runtime": "^6.23.0",
-        "backoff": "^2.5.0",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "urlsafe-base64": "^1.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/common-evented": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/common-evented/-/common-evented-1.50.19.tgz",
-      "integrity": "sha512-UOhZjOCg6Sx2zJSiUfvkYnDKzJpUuYMu7CAwTAQ0D0PlffHv24K0aIhMshPD1J2qCERnpNpiBEw2LmT+fiCgeQ==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/common-timers": {
-      "version": "1.50.18",
-      "resolved": "https://registry.npmjs.org/@ciscospark/common-timers/-/common-timers-1.50.18.tgz",
-      "integrity": "sha512-p8IB2K7M5w3LCNGGEA2Gb+CC4/8pMNFhVrVj2pDc8fc4biUuvIJuCpF1QtMTErg5Ao2MJZkxGagZ+PzXFtfjRw==",
-      "requires": {
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/helper-html": {
-      "version": "1.50.18",
-      "resolved": "https://registry.npmjs.org/@ciscospark/helper-html/-/helper-html-1.50.18.tgz",
-      "integrity": "sha512-PukFeeZwDkwxlobPN242cZ5o8N0KPRwDP8MODWOhGDNNNiYg3JHJvfXj57WMtOS2g86M7yyCi8Pdx0tACXiPIw==",
-      "requires": {
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/helper-image": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/helper-image/-/helper-image-1.50.19.tgz",
-      "integrity": "sha512-NkJZblPGr8oVLLiOHlHCZBTxKKDFS4Q/IEyYn8/plvtSKqJXuZkhGioUEstC3MNAGVbDWEN5iJXJVp9KHJtgvA==",
-      "requires": {
-        "@ciscospark/http-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "exif": "^0.6.0",
-        "gm": "^1.23.0",
-        "lodash": "^4.17.11",
-        "mime-types": "^2.1.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/http-core": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/http-core/-/http-core-1.50.19.tgz",
-      "integrity": "sha512-9jyEV/lwju0guedPYaeKf97FDLtq6WFgC5oI5HyfEnI9oY9jmeFJv8yOfQAdFYHv6KHPU7gpwlxoUs+cARkMjg==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "file-type": "^3.9.0",
-        "global": "^4.3.1",
-        "is-function": "^1.0.1",
-        "lodash": "^4.17.11",
-        "parse-headers": "^2.0.1",
-        "qs": "^6.5.1",
-        "request": "^2.81.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/internal-plugin-conversation": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-conversation/-/internal-plugin-conversation-1.50.19.tgz",
-      "integrity": "sha512-mzIYhKy7I4tC6C/iQMyx+MimdpTT9z1QydIESF7GrrGgmILO369P55ltBjLVoiV6nMh3A9e7vUz2NwOZ02rPKg==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/helper-html": "1.50.18",
-        "@ciscospark/helper-image": "1.50.19",
-        "@ciscospark/internal-plugin-encryption": "1.50.19",
-        "@ciscospark/internal-plugin-user": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/internal-plugin-encryption": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-encryption/-/internal-plugin-encryption-1.50.19.tgz",
-      "integrity": "sha512-XgU3cGfcHrLJfEWJW/qXonsXCq+gXCI5xVDk7OR4LAQsWw+2NeFks/3kW6OApfNauKcmiKLWFY6JKv+a8oxfHQ==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/common-timers": "1.50.18",
-        "@ciscospark/http-core": "1.50.19",
-        "@ciscospark/internal-plugin-mercury": "1.50.19",
-        "@ciscospark/internal-plugin-wdm": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "node-jose": "^0.11.0",
-        "node-kms": "^0.3.2",
-        "node-scr": "^0.2.2"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/internal-plugin-feature": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-feature/-/internal-plugin-feature-1.50.19.tgz",
-      "integrity": "sha512-ZQo6iXW8+cX1z9NOPv8Cm0clqAGQOSVc/ydYL0G5nf0qodxJa/Fa/1OCmq6y0ptewWuP+o3sJH0tCa+xikePMA==",
-      "requires": {
-        "@ciscospark/internal-plugin-wdm": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/internal-plugin-locus": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-locus/-/internal-plugin-locus-1.50.19.tgz",
-      "integrity": "sha512-oBRiR9dp9M1JaEUmSHxVMKf+GWhUJiXURqS17giBjTO+527ITDXkUSeHcDnS/S1TyZ1AvnFjzkWhKOj63qlWhQ==",
-      "requires": {
-        "@ciscospark/internal-plugin-mercury": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/internal-plugin-mercury": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-mercury/-/internal-plugin-mercury-1.50.19.tgz",
-      "integrity": "sha512-vcw9FYFXbUt+XRcLMWFfn+MZAGSJVV8/YBGo9u7NX3vH07LKMIKZXtMiN1g7KgXH8DwlggRQUrR3LMQMnKxONQ==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/common-timers": "1.50.18",
-        "@ciscospark/internal-plugin-feature": "1.50.19",
-        "@ciscospark/internal-plugin-metrics": "1.50.19",
-        "@ciscospark/internal-plugin-wdm": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "backoff": "^2.5.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1",
-        "ws": "^4.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        },
-        "ws": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "@ciscospark/internal-plugin-metrics": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-metrics/-/internal-plugin-metrics-1.50.19.tgz",
-      "integrity": "sha512-USJYJCfggdUQNLdx9bl/+7Pq4G08g/YiFK72g7I1PLKgdTJIMT25qQwA5f4cK8g9VKSOR+MhLe2k5WG2fhTbfw==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/common-timers": "1.50.18",
-        "@ciscospark/internal-plugin-wdm": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/internal-plugin-user": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-user/-/internal-plugin-user-1.50.19.tgz",
-      "integrity": "sha512-pJfbtFycwZZqAiBd9aImapdic2dmGsIvTVHR9xba56KUVjcDc0cNeFxq3KYM1aokPECHeeazgM3WAzU7YKz8qQ==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/internal-plugin-wdm": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/internal-plugin-wdm": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-wdm/-/internal-plugin-wdm-1.50.19.tgz",
-      "integrity": "sha512-cSWUMnRtzM2ggPWiJKfmV4LJq6+mKthnusTM6B/EJ2KQOSkpARRJq88mjrt1LLM5eHdl10c+R0hbp5oeHc2ZZg==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/common-timers": "1.50.18",
-        "@ciscospark/http-core": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/media-engine-webrtc": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/media-engine-webrtc/-/media-engine-webrtc-1.50.19.tgz",
-      "integrity": "sha512-iaUd4mdjAPbH4+vzo51g8ecqkg4aKTsmlkL6DJdimbCXWe4wUU1f8ScoNXjpxtW6LWWfMGuuOsH/n4QIWWB/rQ==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/common-evented": "1.50.19",
-        "ampersand-events": "^2.0.2",
-        "babel-runtime": "^6.23.0",
-        "bowser": "1.9.4",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "lodash-decorators": "^4.3.4",
-        "sdp-transform": "^2.4.0",
-        "webrtc-adapter": "^6.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/plugin-authorization": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization/-/plugin-authorization-1.50.19.tgz",
-      "integrity": "sha512-YS6eUhzWIRdvRd27WRZe93ddn2FDX8uvmxrjCD8z2nBxYLKm3ON2vsrn4nUkS1QRi5jLWTP+bG61qg6Gw4ZzQw==",
-      "requires": {
-        "@ciscospark/plugin-authorization-browser": "1.50.19",
-        "@ciscospark/plugin-authorization-node": "1.50.19",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-authorization-browser": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization-browser/-/plugin-authorization-browser-1.50.19.tgz",
-      "integrity": "sha512-D5ZCrJbLyZt+epN1ofRZP8PsyC61PG28w6G3Go6FbPT9kEBFe09U8Hje3YUwLyqYzpSdD85noUOOzBBvLhNv+Q==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/internal-plugin-wdm": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/plugin-authorization-node": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization-node/-/plugin-authorization-node-1.50.19.tgz",
-      "integrity": "sha512-odkSSflSbDVlG1iu2ZCMg8qr5Yhtg5h0WTiivmqqG5dae8U59rEDeboMeAaqzzb9m0pvHgjLpjjOu16egAMIKg==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/internal-plugin-wdm": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-logger": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-logger/-/plugin-logger-1.50.19.tgz",
-      "integrity": "sha512-WxgexMJUT+/DhcvKHFAV3FPAIJiW8mBvloHPEZhWGT0J52mpsasnXLy7ph4bmOVcexLnAKup6JQ9QQxdRoVpdA==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/plugin-memberships": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-memberships/-/plugin-memberships-1.50.19.tgz",
-      "integrity": "sha512-28X3k7PWVkXiFm/3atBpMC1iKkdXnc+0dSwdLR4+0h3vWzWe9wEIhTSHsaMWfvn90fjYKb0zEaa5GAGTp1AhWQ==",
-      "requires": {
-        "@ciscospark/spark-core": "1.50.19",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-messages": {
-      "version": "1.50.20",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-messages/-/plugin-messages-1.50.20.tgz",
-      "integrity": "sha512-o0GJMTHjSRXTvKbAGXD7e36HoL1p8qG6UlKRVuCZq6SNv/M5H4YF3GpcfdCYfDP7vUtwN82ClWV/y+FWktNbgg==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/internal-plugin-conversation": "1.50.19",
-        "@ciscospark/internal-plugin-mercury": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "debug": "^3.1.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
-    },
-    "@ciscospark/plugin-people": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-people/-/plugin-people-1.50.19.tgz",
-      "integrity": "sha512-kUJvcYH0C10Am09RMQMrcNfYE31oX8wMDkZtFzXmoN5+3xvrx6ohkhQXXiIRuvCKI7+/qaXW13lAzeF0gMZcmw==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-phone": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-phone/-/plugin-phone-1.50.19.tgz",
-      "integrity": "sha512-jrz+xAYL72OszeOeJZFHfwHctsBnCRYBy4feq5LxZAmkkBXUjEB7mIsyEwjOfVnGrVpyG/s9Rq0ViAjKqNeWhQ==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/common-timers": "1.50.18",
-        "@ciscospark/internal-plugin-locus": "1.50.19",
-        "@ciscospark/internal-plugin-metrics": "1.50.19",
-        "@ciscospark/media-engine-webrtc": "1.50.19",
-        "@ciscospark/plugin-people": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-collection-lodash-mixin": "^4.0.0",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "detectrtc": "^1.3.4",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "lodash-decorators": "^4.3.4",
-        "sdp-transform": "^2.4.0",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/plugin-rooms": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-rooms/-/plugin-rooms-1.50.19.tgz",
-      "integrity": "sha512-4dL3b9O1/jhYRUm2SOx3Mtiq+l1XFedVzdQxEP+f939tqReUwmjElriFCWUaUVvYra7CeR8E8HSMJmRWMfTmOw==",
-      "requires": {
-        "@ciscospark/spark-core": "1.50.19",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-team-memberships": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-team-memberships/-/plugin-team-memberships-1.50.19.tgz",
-      "integrity": "sha512-jME4BPuCEWzsY/L7kThmz0Baz8AFWWDKtu1qCcCZ9E/I1Eq2JC137CvxN0I3C+or8y9g7Bj7N+/Fi1+r4bq09w==",
-      "requires": {
-        "@ciscospark/spark-core": "1.50.19",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-teams": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-teams/-/plugin-teams-1.50.19.tgz",
-      "integrity": "sha512-XkxODh9FpIL7A/NDL+gkRlzHpRGY79cvIqwKnwhje7pHoaWLH+nfEC09GUYYSFnCQpEmMjuYiyPYRFzapXQGKA==",
-      "requires": {
-        "@ciscospark/spark-core": "1.50.19",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-webhooks": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-webhooks/-/plugin-webhooks-1.50.19.tgz",
-      "integrity": "sha512-cS9jd8G/xp6FV9logFGHYPrz0+XKXzSSDvfAqDirt/AOhomMsH05UY195Jk9pG/apGKUTsfVj+se7cJIFM5/2Q==",
-      "requires": {
-        "@ciscospark/spark-core": "1.50.19",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/spark-core": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/spark-core/-/spark-core-1.50.19.tgz",
-      "integrity": "sha512-n+1FIT/MA5E8um8+TjpOkA3qIB54TZRezPeNNsy2SEPmOluwnmubSlHvsNo2S/IwMjD5o3cyRzJ+qKXgrvtLxQ==",
-      "requires": {
-        "@ciscospark/common": "1.50.19",
-        "@ciscospark/common-timers": "1.50.18",
-        "@ciscospark/http-core": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-events": "^2.0.2",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "@ciscospark/storage-adapter-local-storage": {
-      "version": "1.50.19",
-      "resolved": "https://registry.npmjs.org/@ciscospark/storage-adapter-local-storage/-/storage-adapter-local-storage-1.50.19.tgz",
-      "integrity": "sha512-z9Vu6/7XNzjLNG5n0LlQTOJvBneNlZoFW22v6J/KimWvuJn8g3+ANQriHLUCOthjtozS/aGy8XrfWtiIAHtywA==",
-      "requires": {
-        "@ciscospark/spark-core": "1.50.19",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -815,6 +289,585 @@
         "@webassemblyjs/ast": "1.4.3",
         "@webassemblyjs/wast-parser": "1.4.3",
         "long": "^3.2.0"
+      }
+    },
+    "@webex/common": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.60.2.tgz",
+      "integrity": "sha512-aCpwWhpMk6VO1c7v7tM4K4qvI1o+rza0NZcGvE1PqpADzS+x4m5v4bUBSm3zrXfp5Sv1xmjxm91IpLyxORjuiw==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "urlsafe-base64": "^1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/common-evented": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/common-evented/-/common-evented-1.60.2.tgz",
+      "integrity": "sha512-UqXdKc2+U7JSclWApxJK4sR3ysLn5hTnZvrfQTpEq06IuPPO7IO0JTWuWuI82tUoVgGqE6m0h+C7JlvNmqueHg==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/common-timers": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.60.2.tgz",
+      "integrity": "sha512-zFPmcqNnx1nuzV0hd4EW5FaBrG/+ACwvWADOiWB91ghF0okBQgQQsQHgGji0rR7CPuHS7sSStK0d8hA4bkJReg==",
+      "requires": {
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/helper-html": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.60.2.tgz",
+      "integrity": "sha512-flif1a2J3rAWW9G5L8J2D+/5aL+qrg4o5A+kQCK8ZkaLIs+h6ja4HJR7NzJZydjL/hWsMarUitFXSGW7sqXj/A==",
+      "requires": {
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/helper-image": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.60.2.tgz",
+      "integrity": "sha512-2i1Cnj/bHoPor4o0FGDdUSFf/EOGT8UI9FhtDdeQP7PDOHiU4q4TsJBPV9nHIUsRxYT67rdmX8egZnGhvSM/Jw==",
+      "requires": {
+        "@webex/http-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "exif": "^0.6.0",
+        "gm": "^1.23.0",
+        "lodash": "^4.17.11",
+        "mime-types": "^2.1.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/http-core": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.60.2.tgz",
+      "integrity": "sha512-6TwIamL8Wsw7lsrtMg6MkiE9Sl9jrNjkqbg01yZ+F0oYinGgG3F6uTb/V+RIzuL4uKp6tc6CzGW3zRoS6L7J+w==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "file-type": "^3.9.0",
+        "global": "^4.3.1",
+        "is-function": "^1.0.1",
+        "lodash": "^4.17.11",
+        "parse-headers": "^2.0.1",
+        "qs": "^6.5.1",
+        "request": "^2.81.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-conversation": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.60.2.tgz",
+      "integrity": "sha512-6TuMazS7FUNQSQoxuHx8xAIonWaD8sTi9ykCUFlYmdbXhfGeI+cu7IuHeFaHO8QH3An+Ckt0wFCtzDS9O+uGUw==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/helper-html": "1.60.2",
+        "@webex/helper-image": "1.60.2",
+        "@webex/internal-plugin-encryption": "1.60.2",
+        "@webex/internal-plugin-user": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-encryption": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.60.2.tgz",
+      "integrity": "sha512-GvuzAWzAtv8//WFo5URfb7ggiQoczGT5GsAfdzA3at4mA+EZCansBb0zT2rDr70wMZkT9WqocHuAQR2jHPj0jg==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/common-timers": "1.60.2",
+        "@webex/http-core": "1.60.2",
+        "@webex/internal-plugin-mercury": "1.60.2",
+        "@webex/internal-plugin-wdm": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "node-jose": "^0.11.0",
+        "node-kms": "^0.3.2",
+        "node-scr": "^0.2.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-feature": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.60.2.tgz",
+      "integrity": "sha512-HnCkZxLOtltxukaYHCtaeY9qKu1DUrFDr4j5mdj0YIx4TP69BzhbYTECfaTS27COLkhMFrVaWUCG06fKJYHp6A==",
+      "requires": {
+        "@webex/internal-plugin-wdm": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-locus": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-locus/-/internal-plugin-locus-1.60.2.tgz",
+      "integrity": "sha512-+tolF9jUKgk6bW1kGt11xc6P+a5vtPj4xRf9+YX5HG90X5H3s2H9080mOQcvNPEp2KbnhIEpns0hdKQKp7CyeQ==",
+      "requires": {
+        "@webex/internal-plugin-mercury": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-mercury": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.60.2.tgz",
+      "integrity": "sha512-DKe/gP3zx5RgWLNOa0oLslxV4Wa+AT5fJFv+6uzcosaOHs9vYbLj7gT/gUpLrUi6GBgSb4HfyymY9w8ZW6+gXQ==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/common-timers": "1.60.2",
+        "@webex/internal-plugin-feature": "1.60.2",
+        "@webex/internal-plugin-metrics": "1.60.2",
+        "@webex/internal-plugin-wdm": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1",
+        "ws": "^4.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ws": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "@webex/internal-plugin-metrics": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.60.2.tgz",
+      "integrity": "sha512-lpHYI4E4c3GbTTZ+/8MVwf9Rxw2tP03Fzl9iqg/sF8fhR2WKtKtKxex0egwFDPqRhloZr0I0KkijBE8yqczg0g==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/common-timers": "1.60.2",
+        "@webex/internal-plugin-wdm": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/internal-plugin-user": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.60.2.tgz",
+      "integrity": "sha512-/wsZJKlBfA31tBbMEBsJJhvTO00MY8spdWOLHW79T36I7eaT5O6HVIXcvgnNJvKzD6g8Dq2PhYU7SJZsvdCS2g==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/internal-plugin-wdm": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-wdm": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.60.2.tgz",
+      "integrity": "sha512-8B6vxblMDyJ5TgvQjueYdbtfXyZIHhWbExl4znGSYXW0ng+cJAS3VMZVZA+zDhvda7WwvoZv9kbUZbug0vyjMQ==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/common-timers": "1.60.2",
+        "@webex/http-core": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/media-engine-webrtc": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/media-engine-webrtc/-/media-engine-webrtc-1.60.2.tgz",
+      "integrity": "sha512-tSrnMWozPppe/mMw/wLtXBpamZIXZuPRTUOs2jJl+wWAnLmKV/RFeMkv4qClNYWNlpAYli4gZ9GzbX8a63RFWw==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/common-evented": "1.60.2",
+        "ampersand-events": "^2.0.2",
+        "babel-runtime": "^6.23.0",
+        "bowser": "1.9.4",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "lodash-decorators": "^4.3.4",
+        "sdp-transform": "^2.4.0",
+        "webrtc-adapter": "^6.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/plugin-authorization": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.60.2.tgz",
+      "integrity": "sha512-PDO9PE7lAJByH6S0wAJLKEmM31G0/OKTNDW+eZ4F9yDolgrIz/8jpiorz7yvHrUhl0Nw38XLa0jFYt+JhYISUQ==",
+      "requires": {
+        "@webex/plugin-authorization-browser": "1.60.2",
+        "@webex/plugin-authorization-node": "1.60.2",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-authorization-browser": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.60.2.tgz",
+      "integrity": "sha512-YiHRUKa5ImpucPUpctzJKhdJ4ANyUKN0j2Qt9m35/7mMmx6G9CuaZMKTzYUtaAqxNAnlGGlXj6oe2OR3t7953Q==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/internal-plugin-wdm": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/plugin-authorization-node": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.60.2.tgz",
+      "integrity": "sha512-/pn4g61bhPwiPwPvwiow5Kj44Pmc8A3vFXMy43D8BapVtKGI7bv+Gt1rMBAFOn5HR7yqNaWjb8AUUS+xK7KQ1g==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/internal-plugin-wdm": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-logger": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.60.2.tgz",
+      "integrity": "sha512-VaS2yJGvqMsKCicgAZicYpza4SoH7K8VVaD664jIuzCzPVyL2qQCDWvnZRG5iFBU5ZkJihn+jBJS2Lx9SMMBgw==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/plugin-memberships": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.60.2.tgz",
+      "integrity": "sha512-4CeWM4GUPoXNMYIyNBKQyS8dwyFXoklmEPOENGV8HW6K57/E+ThFmft2iD+KijbtyKQ+i0KyaCiAVhyHvkDc5g==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/internal-plugin-conversation": "1.60.2",
+        "@webex/internal-plugin-mercury": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-messages": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.60.2.tgz",
+      "integrity": "sha512-TV768cp3Ctx7/9WCDM4KBCjvVvuT5tIybC7a/5edVjeLqa/Mio0BgoUzPUox4b8k7aXb+aSTUJGRk3BHwqszuw==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/internal-plugin-conversation": "1.60.2",
+        "@webex/internal-plugin-mercury": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-people": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.60.2.tgz",
+      "integrity": "sha512-SP38f+PKap/6CA3CCJewiQCf2JQdI/vb9YebypsMBtEXtX/MXg/WyvTd0zvacJToGqVtLmPHfT5N1kSw+yUH4Q==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-phone": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-phone/-/plugin-phone-1.60.2.tgz",
+      "integrity": "sha512-Fb+soZVH9Q0P6I7FjR+o6oCToxPP4EdzJ4xmGF/4kFFUR2KgBOvmN6tWhqWvQYqif28PoNBWwOdFJ3IKWI+3ug==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/common-timers": "1.60.2",
+        "@webex/internal-plugin-locus": "1.60.2",
+        "@webex/internal-plugin-metrics": "1.60.2",
+        "@webex/media-engine-webrtc": "1.60.2",
+        "@webex/plugin-people": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-collection-lodash-mixin": "^4.0.0",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "detectrtc": "^1.3.4",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "lodash-decorators": "^4.3.4",
+        "sdp-transform": "^2.4.0",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/plugin-rooms": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.60.2.tgz",
+      "integrity": "sha512-W7f5OyYQwyWv0vAda7myxvIZzrpjlhIsgPNuZ7OwGAsW0UOHX4R5W48237RQr1DvOf9rcEn5vcMJuBcDIaX4xw==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/internal-plugin-conversation": "1.60.2",
+        "@webex/internal-plugin-mercury": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-team-memberships": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.60.2.tgz",
+      "integrity": "sha512-S2YxryX/zCRLW4O8HEGWE6ErB9WRGLb7zjbdWTXs8En6n4dOPeEFjBWw+5M6bnAQz9RsVUhXn3v/v3K9swD3hQ==",
+      "requires": {
+        "@webex/webex-core": "1.60.2",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-teams": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.60.2.tgz",
+      "integrity": "sha512-7MOv+llmLS4tEnUvKbNjoe8B2JopJP9UShWdlumgNvtMgY8n2e7rBV7QWMsq9WYFwZyZMon+E/1JQqpVWjY+vQ==",
+      "requires": {
+        "@webex/webex-core": "1.60.2",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-webhooks": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.60.2.tgz",
+      "integrity": "sha512-Me3nnezKibc6wcgnB2ivVGhkvq0UGbXUkkz+3olRj67z2856o0zeJdtTxXeCcHAuy6zjsfVfTFpKFmx4JxJmYg==",
+      "requires": {
+        "@webex/webex-core": "1.60.2",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/storage-adapter-local-storage": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.60.2.tgz",
+      "integrity": "sha512-iBhWklfJpjrjwFzcNKpJjS0h2d4SMu4aXycuaAAp/Yj8QV0MiGFFKhYBIjpkwZiSbXsYe4IRwnQ24wOEQwRW+w==",
+      "requires": {
+        "@webex/webex-core": "1.60.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/webex-core": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.60.2.tgz",
+      "integrity": "sha512-mXiYLE0sH4oAre7HIMz60s6G926ihcvEvNrqOJ7j097PsVY0eyN9T5m++UxKnQSmppMngHLuXJPBi+XrXe2jGQ==",
+      "requires": {
+        "@webex/common": "1.60.2",
+        "@webex/common-timers": "1.60.2",
+        "@webex/http-core": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-events": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
       }
     },
     "abbrev": {
@@ -2720,36 +2773,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "ciscospark": {
-      "version": "1.50.20",
-      "resolved": "https://registry.npmjs.org/ciscospark/-/ciscospark-1.50.20.tgz",
-      "integrity": "sha512-rkfDCNinOIQ4CMPHmZZh6/+glCDkTWkqYki4vY30NFMHYrnT6USi8Iciy4RMAjc6gLd2xYkoFL5SO8h6D74d5w==",
-      "requires": {
-        "@ciscospark/internal-plugin-wdm": "1.50.19",
-        "@ciscospark/plugin-authorization": "1.50.19",
-        "@ciscospark/plugin-logger": "1.50.19",
-        "@ciscospark/plugin-memberships": "1.50.19",
-        "@ciscospark/plugin-messages": "1.50.20",
-        "@ciscospark/plugin-people": "1.50.19",
-        "@ciscospark/plugin-phone": "1.50.19",
-        "@ciscospark/plugin-rooms": "1.50.19",
-        "@ciscospark/plugin-team-memberships": "1.50.19",
-        "@ciscospark/plugin-teams": "1.50.19",
-        "@ciscospark/plugin-webhooks": "1.50.19",
-        "@ciscospark/spark-core": "1.50.19",
-        "@ciscospark/storage-adapter-local-storage": "1.50.19",
-        "babel-polyfill": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -3859,9 +3882,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -5307,19 +5330,12 @@
       "dev": true
     },
     "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "requires": {
         "min-document": "^2.19.0",
-        "process": "~0.5.1"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-        }
+        "process": "^0.11.10"
       }
     },
     "global-modules": {
@@ -5407,9 +5423,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -9341,8 +9357,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -10397,9 +10412,9 @@
       "integrity": "sha512-XAVZQO4qsfzVTHorF49zCpkdxiGmPNjA8ps8RcJGtGP3QJ/A8I9/SVg/QnkAFDMXIyGbHZBBFwYBw6WdnhT96w=="
     },
     "sdp-transform": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.7.0.tgz",
-      "integrity": "sha512-v8/zfKeDKBEXKMf4UT91owHoXM6O+s8gEVtCVSvrAd2eEtuv5u4TKcTXX4a9qrQM3T2Ycr9rLyU+Ww3ZiCiaGQ=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.8.0.tgz",
+      "integrity": "sha512-0sacVJs3KzYVm89QDRiZN5eWjBidSGB4F2oYuMOhHfdiKzkZVAhh/UOG5XzjaSlrhWVHxqR7MpQe5lWA9DfsSg=="
     },
     "semver": {
       "version": "5.5.0",
@@ -11814,6 +11829,36 @@
         "@webassemblyjs/wasm-parser": "1.4.3",
         "@webassemblyjs/wast-parser": "1.4.3",
         "long": "^3.2.0"
+      }
+    },
+    "webex": {
+      "version": "1.60.2",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-1.60.2.tgz",
+      "integrity": "sha512-nhY3UbvuYujnpKBZlNPIvfJLaDTTbpw1aupgXYPtLO72iqgdoEzW7RIHNMK/WY4IkVT31WdMPoveEx+QrTCCBw==",
+      "requires": {
+        "@webex/internal-plugin-wdm": "1.60.2",
+        "@webex/plugin-authorization": "1.60.2",
+        "@webex/plugin-logger": "1.60.2",
+        "@webex/plugin-memberships": "1.60.2",
+        "@webex/plugin-messages": "1.60.2",
+        "@webex/plugin-people": "1.60.2",
+        "@webex/plugin-phone": "1.60.2",
+        "@webex/plugin-rooms": "1.60.2",
+        "@webex/plugin-team-memberships": "1.60.2",
+        "@webex/plugin-teams": "1.60.2",
+        "@webex/plugin-webhooks": "1.60.2",
+        "@webex/storage-adapter-local-storage": "1.60.2",
+        "@webex/webex-core": "1.60.2",
+        "babel-polyfill": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
       }
     },
     "webex-js-eventpump": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^4.3.1",
-    "ciscospark": "^1.50.20",
     "dotenv": "^7.0.0",
     "express": "^4.15.2",
     "font-awesome": "^4.7.0",
@@ -19,6 +18,7 @@
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "socket.io": "^1.7.3",
+    "webex": "^1.60.2",
     "webex-js-eventpump": "^1.0.4",
     "webex-read-info": "^1.0.2"
   },


### PR DESCRIPTION
Update to use the new webex javascript sdk (formerly called ciscospark).

This version of the SDK supports the ability to call a listen() function on the message, membership and rooms modules, which will generate events that the client registers listeners for.  This replaces the functionality that was previously supplied in the private eventPump "shim module".

This version of the SDK also supports a listWithReadStatus() method on the memberships and rooms modules, as well as an updateLastRead() method on the membership module.  These functions allow a custom client to discover and update user's read status and replaces the functionality that was previously supplied in the readStatus "shim module"